### PR TITLE
Changed the request body to use hw_string and created per consumer HTTP ...

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ fi
 # Getting libuv
 if [ ! -d "lib/libuv" ]; then
     echo "git clone -b v0.10 https://github.com/joyent/libuv.git lib/libuv"
-    git clone -b v0.10 https://github.com/joyent/libuv.git lib/libuv
+    git clone https://github.com/joyent/libuv.git lib/libuv
 fi
 
 # Getting Gyp build environment.

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -155,7 +155,7 @@ typedef struct
     int keep_alive;
 	char* url;
     void* headers;
-    char* body;
+    hw_string* body;
     int body_length;
 } http_request;
 
@@ -169,7 +169,6 @@ HAYWIRE_EXTERN int hw_init_with_config(configuration* config);
 HAYWIRE_EXTERN int hw_http_open(int threads);
 HAYWIRE_EXTERN void hw_http_add_route(char* route, http_request_callback callback, void* user_data);
 HAYWIRE_EXTERN char* hw_get_header(http_request* request, char* key);
-HAYWIRE_EXTERN char* hw_get_body(http_request* request);
 
 HAYWIRE_EXTERN void hw_free_http_response(hw_http_response* response);
 HAYWIRE_EXTERN void hw_set_http_version(hw_http_response* response, unsigned short major, unsigned short minor);

--- a/src/haywire/connection_consumer.c
+++ b/src/haywire/connection_consumer.c
@@ -93,6 +93,10 @@ void connection_consumer_start(void *arg)
     
     ctx = arg;
     loop = uv_loop_new();
+    listener_event_loops[ctx->index] = *loop;
+    
+    http_request_cache_configure_listener(loop, &listener_async_handles[ctx->index]);
+    uv_barrier_wait(listeners_created_barrier);
     
     rc = uv_async_init(loop, &ctx->async_handle, connection_consumer_close);
     uv_unref((uv_handle_t*) &ctx->async_handle);

--- a/src/haywire/connection_consumer.h
+++ b/src/haywire/connection_consumer.h
@@ -17,6 +17,7 @@ typedef unsigned char handle_storage_t[sizeof(union stream_handle2)];
 
 struct server_ctx
 {
+    int index;
     handle_storage_t server_handle;
     unsigned int num_connects;
     uv_async_t async_handle;

--- a/src/haywire/http_response.c
+++ b/src/haywire/http_response.c
@@ -57,19 +57,6 @@ void hw_set_body(hw_http_response* response, hw_string* body)
     resp->body = *body;
 }
 
-char* itoa(int val, int base)
-{	
-	static char buf[32] = {0};
-	int i = 30;
-	
-	for(; val && i ; --i, val /= base)
-    {
-        
-		buf[i] = "0123456789abcdef"[val % base];
-    }
-	return &buf[i+1];
-}
-
 hw_string* create_response_buffer(hw_http_response* response)
 {
     http_response* resp = (http_response*)response;
@@ -95,8 +82,7 @@ hw_string* create_response_buffer(hw_http_response* response)
     /* Add the body */
     APPENDSTRING(response_string, "Content-Length: ");
     
-    content_length.value = itoa(resp->body.length + 3, 10);
-    content_length.length = strlen(content_length.value);
+    string_from_int(&content_length, resp->body.length + 3, 10);
     append_string(response_string, &content_length);
     APPENDSTRING(response_string, CRLF CRLF);
     

--- a/src/haywire/http_response_cache.c
+++ b/src/haywire/http_response_cache.c
@@ -11,88 +11,111 @@
 #define CRLF "\r\n"
 KHASH_MAP_INIT_STR(string_hashmap, hw_string*)
 
-static khash_t(string_hashmap)* http_request_cache;
 static uv_timer_t cache_invalidation_timer;
-static uv_rwlock_t http_response_cache_lock;
+static uv_key_t thread_cache_key;
 
 void initialize_http_request_cache();
 void free_http_request_cache();
 void http_request_cache_timer(uv_timer_t* handle, int status);
-void create_cached_http_request(char* http_status);
-void set_cached_request(char* http_status, hw_string* cache_entry);
+void create_cached_http_request(khash_t(string_hashmap)* http_request_cache, char* http_status);
+void set_cached_request(khash_t(string_hashmap)* http_request_cache, char* http_status, hw_string* cache_entry);
 hw_string* get_cached_request(char* http_status);
 
 void initialize_http_request_cache()
 {
-    http_request_cache = kh_init(string_hashmap);
-    uv_rwlock_init(&http_response_cache_lock);
-    uv_timer_init(uv_loop, &cache_invalidation_timer);
-    uv_timer_start(&cache_invalidation_timer, http_request_cache_timer, 500, 500);
+    uv_key_create(&thread_cache_key);
 }
 
-void free_http_request_cache()
+void http_request_cache_configure_listener(uv_loop_t* loop, uv_async_t* handle)
 {
-    const char* k;
-    const hw_string* v;
-    kh_foreach(http_request_cache, k, v,
-               {
-                   free((char*)k);
-                   free(v->value);
-                   free((char*)v);
-               });
-    kh_destroy(string_hashmap, http_request_cache);
-    http_request_cache = kh_init(string_hashmap);
+    uv_timer_t* cache_invalidation_timer = malloc(sizeof(uv_timer_t));
+    uv_timer_init(loop, cache_invalidation_timer);
+    uv_timer_start(cache_invalidation_timer, http_request_cache_timer, 500, 500);
+    uv_unref((uv_handle_t*) cache_invalidation_timer);
 }
 
 void http_request_cache_timer(uv_timer_t* handle, int status)
 {
-    // TODO: Re-enable response cache when reader/writer lock is fixed.
-    //free_http_request_cache();
+    khash_t(string_hashmap)* http_request_cache = uv_key_get(&thread_cache_key);
+    if (http_request_cache != NULL)
+    {
+        free_http_request_cache(http_request_cache);
+    }
 }
 
-void create_cached_http_request(char* http_status)
+void free_http_request_cache(khash_t(string_hashmap)* http_request_cache)
 {
-    char* buffer = calloc(1024, 1);
-    int length;
-    hw_string* cache_entry;
+    const char* k;
+    hw_string* v;
     
-    strcpy(buffer, "HTTP/1.1 ");
-    strcat(buffer, http_status);
-    strcat(buffer, CRLF);
-    strcat(buffer, "Server: Haywire/master");
-    strcat(buffer, CRLF);
-    strcat(buffer, "Date: Fri, 31 Aug 2011 00:31:53 GMT");
-    strcat(buffer, CRLF);
+    kh_foreach(http_request_cache, k, v,
+               {
+                   free((char*)k);
+                   free(v->value);
+                   free(v);
+               });
     
-    length = strlen(buffer);
-    
-    cache_entry = malloc(sizeof(hw_string));
-    cache_entry->value = buffer;
-    cache_entry->length = length;
-    set_cached_request(http_status, cache_entry);
+    kh_destroy_string_hashmap(http_request_cache);
+    uv_key_set(&thread_cache_key, NULL);
 }
 
+void create_cached_http_request(khash_t(string_hashmap)* http_request_cache, char* http_status)
+{
+    hw_string* cache_entry = malloc(sizeof(hw_string));
+    cache_entry->value = calloc(1024, 1);
+    cache_entry->length = 0;
+    
+    append_string(cache_entry, http_v1_1);
+    APPENDSTRING(cache_entry, http_status);
+    APPENDSTRING(cache_entry, CRLF);
+    append_string(cache_entry, server_name);
+    APPENDSTRING(cache_entry, CRLF);
+    APPENDSTRING(cache_entry, "Date: Fri, 31 Aug 2011 00:31:53 GMT");
+    APPENDSTRING(cache_entry, CRLF);
+    
+    set_cached_request(http_request_cache, http_status, cache_entry);
+}
 
-void set_cached_request(char* http_status, hw_string* cache_entry)
+void set_cached_request(khash_t(string_hashmap)* http_request_cache, char* http_status, hw_string* cache_entry)
 {
     int ret;
+    int is_missing;
     khiter_t key;
+    hw_string* val;
     
-    // TODO: Fix read/write lock.
-    //uv_rwlock_wrlock(&http_response_cache_lock);
+    key = kh_get(string_hashmap, http_request_cache, http_status);
+    if (key != 0)
+    {
+        /* cache entry already exists and another thread beat us. Ignore. */
+        val = kh_value(http_request_cache, key);
+        is_missing = (key == kh_end(http_request_cache));
+        
+        if (!is_missing)
+        {
+            printf("FOUND\n");
+            //kh_del(string_hashmap, http_request_cache, key);
+        }
+    }
     
     key = kh_put(string_hashmap, http_request_cache, dupstr(http_status), &ret);
     kh_value(http_request_cache, key) = cache_entry;
-    
-    //uv_rwlock_wrunlock(&http_response_cache_lock);
 }
 
 hw_string* get_cached_request(char* http_status)
 {
     int is_missing;
     void* val;
+    khash_t(string_hashmap)* http_request_cache;
     
-    uv_rwlock_rdlock(&http_response_cache_lock);
+    /* This thread hasn't created a response cache so create one */
+    http_request_cache = uv_key_get(&thread_cache_key);
+    if (http_request_cache == NULL)
+    {
+        http_request_cache = kh_init(string_hashmap);
+        uv_key_set(&thread_cache_key, http_request_cache);
+        //printf("CREATED CACHE\n");
+    }
+    
     khiter_t key = kh_get(string_hashmap, http_request_cache, http_status);
     if (key == 0)
     {
@@ -105,20 +128,23 @@ hw_string* get_cached_request(char* http_status)
     }
     if (is_missing)
     {
-        create_cached_http_request(http_status);
+        create_cached_http_request(http_request_cache, http_status);
     }
     
     key = kh_get(string_hashmap, http_request_cache, http_status);
-    val = kh_value(http_request_cache, key);
-    is_missing = (key == kh_end(http_request_cache));
-    
-    uv_rwlock_rdunlock(&http_response_cache_lock);
-    
+    if (key == 0)
+    {
+        is_missing = 1;
+    }
+    else
+    {
+        val = kh_value(http_request_cache, key);
+        is_missing = (key == kh_end(http_request_cache));
+    }
     if (is_missing)
     {
         return NULL;
     }
-
     return val;
 }
 

--- a/src/haywire/http_response_cache.h
+++ b/src/haywire/http_response_cache.h
@@ -1,5 +1,7 @@
 #pragma once
+#include "uv.h"
 #include "haywire.h"
 
 void initialize_http_request_cache();
 hw_string* get_cached_request(char* http_status);
+void http_request_cache_configure_listener(uv_loop_t* loop, uv_async_t* handle);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -25,6 +25,13 @@ union stream_handle
 
 extern void* routes;
 extern uv_loop_t* uv_loop;
+extern hw_string* http_v1_0;
+extern hw_string* http_v1_1;
+extern hw_string* server_name;
+extern int listener_count;
+extern uv_async_t* listener_async_handles;
+extern uv_loop_t* listener_event_loops;
+extern uv_barrier_t* listeners_created_barrier;
 
 http_connection* create_http_connection();
 void http_stream_on_connect(uv_stream_t* stream, int status);

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -3,6 +3,16 @@
 #include <string.h>
 #include "haywire.h"
 
+hw_string* create_string(const char* value)
+{
+    int length = strlen(value);
+    hw_string* str = malloc(sizeof(hw_string));
+    str->value = malloc(length);
+    memcpy(str->value, value, length);
+    str->length = length;
+    return str;
+}
+
 void append_string(hw_string* destination, hw_string* source)
 {
     void* location = (char*)destination->value + destination->length;
@@ -13,10 +23,26 @@ void append_string(hw_string* destination, hw_string* source)
 /* Added because of http://stackoverflow.com/questions/8359966/strdup-returning-address-out-of-bounds */
 char* dupstr(const char *s)
 {
-    char *const result = malloc(strlen(s) + 1);
+    char* result = malloc(strlen(s) + 1);
     if (result != NULL)
     {
         strcpy(result, s);
     }
     return result;
+}
+
+void string_from_int(hw_string* str, int val, int base)
+{
+	static char buf[32] = {0};
+	int i = 30;
+	int length = 0;
+    
+	for(; val && i ; --i, val /= base)
+    {
+		buf[i] = "0123456789abcdef"[val % base];
+        length++;
+    }
+    
+    str->value = &buf[i+1];
+    str->length = length;
 }

--- a/src/haywire/hw_string.h
+++ b/src/haywire/hw_string.h
@@ -1,4 +1,6 @@
 #pragma once
 
+hw_string* create_string(const char* value);
 void append_string(hw_string* destination, hw_string* source);
 char* dupstr(const char *s);
+void string_from_int(hw_string* str, int val, int base);

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -17,7 +17,7 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
     hw_string body;
     hw_string keep_alive_name;
     hw_string keep_alive_value;
-        
+    
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
     


### PR DESCRIPTION
...response caches and purge timers to eliminate any shared state and locking.
